### PR TITLE
removing empty dict parameter

### DIFF
--- a/plugins/card_fetcher.py
+++ b/plugins/card_fetcher.py
@@ -103,7 +103,7 @@ class CardFetcher(GladosPluginBase):
 
             cfbSearchUrl = 'http://store.channelfireball.com/products/search?query={}'.format(urllib.parse.quote((match)))
 
-            self.send('<{}|CFB> says the price of {} is {}'.format(cfbSearchUrl, match, price), msg['channel'], {})
+            self.send('<{}|CFB> says the price of {} is {}'.format(cfbSearchUrl, match, price), msg['channel'])
 
 
 '''


### PR DESCRIPTION
Fixing issue where the price matching feature fails because of `attachments` not being `None`
